### PR TITLE
Semi-fix input box sizing issue

### DIFF
--- a/jquery.tokenize.js
+++ b/jquery.tokenize.js
@@ -348,10 +348,9 @@
          * Resize search input according the value length
          */
         resizeSearchInput: function(){
-
-            this.searchInput.attr('size', (this.searchInput.val().length > 1 ? this.searchInput.val().length : 5));
+            var tokenLength = Number(this.searchInput.val().length)+5;
+            this.searchInput.attr('size', tokenLength);
             this.updatePlaceholder();
-
         },
 
         /**


### PR DESCRIPTION
As it stands now, typing more than a few characters in your input box causes the size to be set improperly. (see this example using your demo, where about 3 characters are cut off: https://gyazo.com/1d88753ea702fae2a00f33f0041a82fd). The previous way it was being set was incorrect, and caused the size attr to not reflect that actual size of the token. I have fixed this, but also added 5 to the normal value. This is because certain characters are wider than others, and can cause the same issue. The increased size accounts for that fact. 

It's still not perfect, but it's much better.